### PR TITLE
Update clickhouse-copier.md

### DIFF
--- a/docs/en/operations/utilities/clickhouse-copier.md
+++ b/docs/en/operations/utilities/clickhouse-copier.md
@@ -34,7 +34,7 @@ To reduce network traffic, we recommend running `clickhouse-copier` on the same 
 The utility should be run manually:
 
 ``` bash
-$ clickhouse-copier --daemon --config keeper.xml --task-path /task/path --base-dir /path/to/dir
+$ clickhouse-copier --daemon --config keeper.xml --task-path /task/path --base-dir /path/to/dir --task-upload-force true
 ```
 
 Parameters:
@@ -43,7 +43,7 @@ Parameters:
 - `config` — The path to the `keeper.xml` file with the parameters for the connection to ClickHouse Keeper.
 - `task-path` — The path to the ClickHouse Keeper node. This node is used for syncing `clickhouse-copier` processes and storing tasks. Tasks are stored in `$task-path/description`.
 - `task-file` — Optional path to file with task configuration for initial upload to ClickHouse Keeper.
-- `task-upload-force` — Force upload `task-file` even if node already exists.
+- `task-upload-force` — Force upload `task-file` even if node already exists(default is false).
 - `base-dir` — The path to logs and auxiliary files. When it starts, `clickhouse-copier` creates `clickhouse-copier_YYYYMMHHSS_<PID>` subdirectories in `$base-dir`. If this parameter is omitted, the directories are created in the directory where `clickhouse-copier` was launched.
 
 ## Format of keeper.xml {#format-of-zookeeper-xml}


### PR DESCRIPTION
Shows that the type of task-upload-force is Boolean.

### Changelog category (leave one):
- Documentation 

### Documentation entry for user-facing changes

- [ ] The original document does not specify the type of task-upload-force directly, which is easy to cause ambiguity.
 

 